### PR TITLE
FragmentScanner: use String::from() in scan() doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,9 @@ impl FragmentScanner {
     ///
     /// ```
     /// let base_dirs = vec![
-    ///     "/usr/lib".to_string(),
-    ///     "/run".to_string(),
-    ///     "/etc".to_string(),
+    ///     String::from("/usr/lib"),
+    ///     String::from("/run"),
+    ///     String::from("/etc"),
     /// ];
     /// let allowed_extensions = vec![
     ///     String::from("toml"),


### PR DESCRIPTION
Use String::from() to be consistent with the example for
FragmentScanner::new().

---

Minor nit on reading the docs.