### PR TITLE
docs: expand description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # liboverdrop
 
-[![Build Status](https://travis-ci.org/overdrop/liboverdrop-rs.svg?branch=master)](https://travis-ci.org/overdrop/liboverdrop-rs)
+[![Build Status](https://travis-ci.com/overdrop/liboverdrop-rs.svg?branch=master)](https://travis-ci.com/overdrop/liboverdrop-rs)
 [![crates.io](https://img.shields.io/crates/v/liboverdrop.svg)](https://crates.io/crates/liboverdrop)
 [![Documentation](https://docs.rs/liboverdrop/badge.svg)](https://docs.rs/liboverdrop)
 
 A simple Rust library to handle configuration fragments.
 
-This crate provides helpers for scanning configuration fragments on disk.
-It support overlaying multiple directories (with priority), and it handles
-configuration dropins.
+This crate provides helpers to scan configuration fragments on disk.
+The goal is to help in writing Linux services which are shipped as part of a [Reproducible OS][reproducible].
+Its name derives from **over**lays and **drop**ins (base directories and configuration fragments).
+
+The main entrypoint is [`FragmentScanner`](struct.FragmentScanner.html). It scans
+for configuration fragments across multiple directories (with increasing priority),
+following these rules:
+
+ * fragments are identified by unique filenames, lexicographically (e.g. `50-default-limits.conf`).
+ * in case of name duplication, last directory wins (e.g. `/etc/svc/custom.conf` can override `/usr/lib/svc/custom.conf`).
+ * a fragment symlinked to `/dev/null` is used to ignore any previous fragment with the same filename.
+
+[reproducible]: http://0pointer.net/blog/projects/stateless.html
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,49 @@
+//! Simple library to handle configuration fragments.
+//!
+//! This crate provides helpers to scan configuration fragments on disk.
+//! The goal is to help in writing Linux services which are shipped as part of a [Reproducible OS][reproducible].
+//! Its name derives from **over**lays and **drop**ins (base directories and configuration fragments).
+//!
+//! The main entrypoint is [`FragmentScanner`](struct.FragmentScanner.html). It scans
+//! for configuration fragments across multiple directories (with increasing priority),
+//! following these rules:
+//!
+//!  * fragments are identified by unique filenames, lexicographically (e.g. `50-default-limits.conf`).
+//!  * in case of name duplication, last directory wins (e.g. `/etc/svc/custom.conf` can override `/usr/lib/svc/custom.conf`).
+//!  * a fragment symlinked to `/dev/null` is used to ignore any previous fragment with the same filename.
+//!
+//! [reproducible]: http://0pointer.net/blog/projects/stateless.html
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! # use liboverdrop::FragmentScanner;
+//! // Scan for fragments under:
+//! //  * /usr/lib/my-crate/config.d/*.toml
+//! //  * /run/my-crate/config.d/*.toml
+//! //  * /etc/my-crate/config.d/*.toml
+//!
+//! let base_dirs = vec![
+//!     "/usr/lib".to_string(),
+//!     "/run".to_string(),
+//!     "/etc".to_string(),
+//! ];
+//! let allowed_extensions = vec![
+//!     String::from("toml"),
+//! ];
+//! let od_cfg = FragmentScanner::new(base_dirs, "my-crate/config.d", false, allowed_extensions);
+//!
+//! let fragments = od_cfg.scan();
+//! for (filename, filepath) in fragments {
+//!     println!("fragment '{}' located at '{}'", filename, filepath.display());
+//! }
+//! ```
+
 use log::trace;
 use std::{collections, fs, path};
 
+/// Configuration fragments scanner.
+#[derive(Debug)]
 pub struct FragmentScanner {
     dirs: Vec<path::PathBuf>,
     ignore_dotfiles: bool,
@@ -25,22 +68,6 @@ impl FragmentScanner {
     ///
     /// `shared_path` is concatenated to each entry in `base_dirs` to form the directory paths to
     /// scan.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let base_dirs = vec![
-    ///     String::from("/usr/lib"),
-    ///     String::from("/run"),
-    ///     String::from("/etc"),
-    /// ];
-    /// let allowed_extensions = vec![
-    ///     String::from("toml"),
-    /// ];
-    ///
-    /// use liboverdrop::FragmentScanner;
-    /// let od_cfg = FragmentScanner::new(base_dirs, "my-crate/config.d", false, allowed_extensions);
-    /// ```
     pub fn new(
         base_dirs: Vec<String>,
         shared_path: &str,
@@ -63,26 +90,7 @@ impl FragmentScanner {
     /// Configuration fragments are stored in the `BTreeMap` in alphanumeric order by filename.
     /// Configuration fragments existing in directories that are scanned later override fragments
     /// of the same filename in directories that are scanned earlier.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let base_dirs = vec![
-    ///     "/usr/lib".to_string(),
-    ///     "/run".to_string(),
-    ///     "/etc".to_string(),
-    /// ];
-    /// let allowed_extensions = vec![
-    ///     String::from("toml"),
-    /// ];
-    ///
-    /// use liboverdrop::FragmentScanner;
-    /// let od_cfg = FragmentScanner::new(base_dirs, "my-crate/config.d", false, allowed_extensions);
-    /// let fragments = od_cfg.scan();
-    /// ```
-    pub fn scan(
-        &self,
-    ) -> collections::BTreeMap<String, path::PathBuf> {
+    pub fn scan(&self) -> collections::BTreeMap<String, path::PathBuf> {
         let mut files_map = collections::BTreeMap::new();
         for dir in &self.dirs {
             trace!("Scanning directory '{}'", dir.display());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,11 @@ impl FragmentScanner {
             dpath.push(shared_path.clone());
             dirs.push(dpath);
         }
-        Self { dirs, ignore_dotfiles, allowed_extensions }
+        Self {
+            dirs,
+            ignore_dotfiles,
+            allowed_extensions,
+        }
     }
 
     /// Scan unique configuration fragments from the set configuration directories. Returns a
@@ -171,7 +175,10 @@ mod tests {
         filename: &String,
         filepath: &String,
     ) -> () {
-        assert_eq!(fragments.get(filename).unwrap(), &path::PathBuf::from(filepath));
+        assert_eq!(
+            fragments.get(filename).unwrap(),
+            &path::PathBuf::from(filepath)
+        );
     }
 
     fn assert_fragments_hit(
@@ -196,19 +203,38 @@ mod tests {
             format!("{}/{}", treedir, "run"),
             format!("{}/{}", treedir, "etc"),
         ];
-        let allowed_extensions = vec![
-            String::from("toml"),
-        ];
+        let allowed_extensions = vec![String::from("toml")];
         let od_cfg = FragmentScanner::new(dirs, "liboverdrop.d", false, allowed_extensions);
 
         let expected_fragments = vec![
-            FragmentNamePath { name: String::from("01-config-a.toml"), path: treedir.to_owned() + "/etc/liboverdrop.d/01-config-a.toml" },
-            FragmentNamePath { name: String::from("02-config-b.toml"), path: treedir.to_owned() + "/run/liboverdrop.d/02-config-b.toml" },
-            FragmentNamePath { name: String::from("03-config-c.toml"), path: treedir.to_owned() + "/etc/liboverdrop.d/03-config-c.toml" },
-            FragmentNamePath { name: String::from("04-config-d.toml"), path: treedir.to_owned() + "/usr/lib/liboverdrop.d/04-config-d.toml" },
-            FragmentNamePath { name: String::from("05-config-e.toml"), path: treedir.to_owned() + "/etc/liboverdrop.d/05-config-e.toml" },
-            FragmentNamePath { name: String::from("06-config-f.toml"), path: treedir.to_owned() + "/run/liboverdrop.d/06-config-f.toml" },
-            FragmentNamePath { name: String::from("07-config-g.toml"), path: treedir.to_owned() + "/etc/liboverdrop.d/07-config-g.toml" },
+            FragmentNamePath {
+                name: String::from("01-config-a.toml"),
+                path: treedir.to_owned() + "/etc/liboverdrop.d/01-config-a.toml",
+            },
+            FragmentNamePath {
+                name: String::from("02-config-b.toml"),
+                path: treedir.to_owned() + "/run/liboverdrop.d/02-config-b.toml",
+            },
+            FragmentNamePath {
+                name: String::from("03-config-c.toml"),
+                path: treedir.to_owned() + "/etc/liboverdrop.d/03-config-c.toml",
+            },
+            FragmentNamePath {
+                name: String::from("04-config-d.toml"),
+                path: treedir.to_owned() + "/usr/lib/liboverdrop.d/04-config-d.toml",
+            },
+            FragmentNamePath {
+                name: String::from("05-config-e.toml"),
+                path: treedir.to_owned() + "/etc/liboverdrop.d/05-config-e.toml",
+            },
+            FragmentNamePath {
+                name: String::from("06-config-f.toml"),
+                path: treedir.to_owned() + "/run/liboverdrop.d/06-config-f.toml",
+            },
+            FragmentNamePath {
+                name: String::from("07-config-g.toml"),
+                path: treedir.to_owned() + "/etc/liboverdrop.d/07-config-g.toml",
+            },
         ];
 
         let fragments = od_cfg.scan();
@@ -226,12 +252,8 @@ mod tests {
     #[test]
     fn basic_override_restrict_extensions() {
         let treedir = "tests/fixtures/tree-basic";
-        let dirs = vec![
-            format!("{}/{}", treedir, "etc"),
-        ];
-        let allowed_extensions = vec![
-            String::from("toml"),
-        ];
+        let dirs = vec![format!("{}/{}", treedir, "etc")];
+        let allowed_extensions = vec![String::from("toml")];
         let od_cfg = FragmentScanner::new(dirs, "liboverdrop.d", false, allowed_extensions);
 
         let fragments = od_cfg.scan();
@@ -244,9 +266,7 @@ mod tests {
     #[test]
     fn basic_override_allow_all_extensions() {
         let treedir = "tests/fixtures/tree-basic";
-        let dirs = vec![
-            format!("{}/{}", treedir, "etc"),
-        ];
+        let dirs = vec![format!("{}/{}", treedir, "etc")];
         let allowed_extensions = vec![];
         let od_cfg = FragmentScanner::new(dirs, "liboverdrop.d", false, allowed_extensions);
 
@@ -260,9 +280,7 @@ mod tests {
     #[test]
     fn basic_override_ignore_hidden() {
         let treedir = "tests/fixtures/tree-basic";
-        let dirs = vec![
-            format!("{}/{}", treedir, "etc"),
-        ];
+        let dirs = vec![format!("{}/{}", treedir, "etc")];
         let allowed_extensions = vec![];
         let od_cfg = FragmentScanner::new(dirs, "liboverdrop.d", true, allowed_extensions);
 
@@ -275,9 +293,7 @@ mod tests {
     #[test]
     fn basic_override_allow_hidden() {
         let treedir = "tests/fixtures/tree-basic";
-        let dirs = vec![
-            format!("{}/{}", treedir, "etc"),
-        ];
+        let dirs = vec![format!("{}/{}", treedir, "etc")];
         let allowed_extensions = vec![];
         let od_cfg = FragmentScanner::new(dirs, "liboverdrop.d", false, allowed_extensions);
 


### PR DESCRIPTION
This improves documentation and re-format the codebase:
 * added a rustdoc crate summary and unify examples
 * expanded README description to match rustdoc
 * run rustfmt on the whole codebase 