### PR TITLE
Directly import `BTreeMap` and `PathBuf`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,8 @@
 //! ```
 
 use log::trace;
-use std::{collections, fs, path};
+use std::collections::BTreeMap;
+use std::{fs, path};
 
 /// Configuration fragments scanner.
 #[derive(Debug)]
@@ -88,14 +89,14 @@ impl FragmentScanner {
     }
 
     /// Scan unique configuration fragments from the set configuration directories. Returns a
-    /// `collections::BTreeMap` indexed by configuration fragment filename, holding the path where
+    /// `std::collections::BTreeMap` indexed by configuration fragment filename, holding the path where
     /// the unique configuration fragment is located.
     ///
     /// Configuration fragments are stored in the `BTreeMap` in alphanumeric order by filename.
     /// Configuration fragments existing in directories that are scanned later override fragments
     /// of the same filename in directories that are scanned earlier.
-    pub fn scan(&self) -> collections::BTreeMap<String, path::PathBuf> {
-        let mut files_map = collections::BTreeMap::new();
+    pub fn scan(&self) -> BTreeMap<String, path::PathBuf> {
+        let mut files_map = BTreeMap::new();
         for dir in &self.dirs {
             trace!("Scanning directory '{}'", dir.display());
 
@@ -171,7 +172,7 @@ mod tests {
     }
 
     fn assert_fragments_match(
-        fragments: &collections::BTreeMap<String, path::PathBuf>,
+        fragments: &BTreeMap<String, path::PathBuf>,
         filename: &String,
         filepath: &String,
     ) -> () {
@@ -181,17 +182,11 @@ mod tests {
         );
     }
 
-    fn assert_fragments_hit(
-        fragments: &collections::BTreeMap<String, path::PathBuf>,
-        filename: &str,
-    ) -> () {
+    fn assert_fragments_hit(fragments: &BTreeMap<String, path::PathBuf>, filename: &str) -> () {
         assert!(fragments.get(&String::from(filename)).is_some());
     }
 
-    fn assert_fragments_miss(
-        fragments: &collections::BTreeMap<String, path::PathBuf>,
-        filename: &str,
-    ) -> () {
+    fn assert_fragments_miss(fragments: &BTreeMap<String, path::PathBuf>, filename: &str) -> () {
         assert!(fragments.get(&String::from(filename)).is_none());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,13 @@
 
 use log::trace;
 use std::collections::BTreeMap;
-use std::{fs, path};
+use std::fs;
+use std::path::PathBuf;
 
 /// Configuration fragments scanner.
 #[derive(Debug)]
 pub struct FragmentScanner {
-    dirs: Vec<path::PathBuf>,
+    dirs: Vec<PathBuf>,
     ignore_dotfiles: bool,
     allowed_extensions: Vec<String>,
 }
@@ -77,7 +78,7 @@ impl FragmentScanner {
     ) -> Self {
         let mut dirs = Vec::with_capacity(base_dirs.len());
         for bdir in base_dirs {
-            let mut dpath = path::PathBuf::from(bdir);
+            let mut dpath = PathBuf::from(bdir);
             dpath.push(shared_path);
             dirs.push(dpath);
         }
@@ -95,7 +96,7 @@ impl FragmentScanner {
     /// Configuration fragments are stored in the `BTreeMap` in alphanumeric order by filename.
     /// Configuration fragments existing in directories that are scanned later override fragments
     /// of the same filename in directories that are scanned earlier.
-    pub fn scan(&self) -> BTreeMap<String, path::PathBuf> {
+    pub fn scan(&self) -> BTreeMap<String, PathBuf> {
         let mut files_map = BTreeMap::new();
         for dir in &self.dirs {
             trace!("Scanning directory '{}'", dir.display());
@@ -144,7 +145,7 @@ impl FragmentScanner {
                 if !meta.file_type().is_file() {
                     if let Ok(target) = fs::read_link(&fpath) {
                         // A devnull symlink is a special case to ignore previous file-names.
-                        if target == path::PathBuf::from("/dev/null") {
+                        if target == PathBuf::from("/dev/null") {
                             trace!("Nulled config file '{}'", fpath.display());
                             files_map.remove(&fname);
                         }
@@ -172,21 +173,18 @@ mod tests {
     }
 
     fn assert_fragments_match(
-        fragments: &BTreeMap<String, path::PathBuf>,
+        fragments: &BTreeMap<String, PathBuf>,
         filename: &String,
         filepath: &String,
     ) -> () {
-        assert_eq!(
-            fragments.get(filename).unwrap(),
-            &path::PathBuf::from(filepath)
-        );
+        assert_eq!(fragments.get(filename).unwrap(), &PathBuf::from(filepath));
     }
 
-    fn assert_fragments_hit(fragments: &BTreeMap<String, path::PathBuf>, filename: &str) -> () {
+    fn assert_fragments_hit(fragments: &BTreeMap<String, PathBuf>, filename: &str) -> () {
         assert!(fragments.get(&String::from(filename)).is_some());
     }
 
-    fn assert_fragments_miss(fragments: &BTreeMap<String, path::PathBuf>, filename: &str) -> () {
+    fn assert_fragments_miss(fragments: &BTreeMap<String, PathBuf>, filename: &str) -> () {
         assert!(fragments.get(&String::from(filename)).is_none());
     }
 


### PR DESCRIPTION
Directly import `BTreeMap`

In large projects, IMO it can make sense to carry around qualified
names like `collections::BTreeMap`.  But this project is *tiny*.
The repetition isn't worth it, in this context we will always
be using the `std` `BTreeMap`.

---

Directly import `PathBuf`

In large projects, IMO it can make sense to carry around qualified
names.  But this project is *tiny*, and in this context we will always
be using the `PathBuf` from `std`.

---

