### PR TITLE
Don't re-allocate every file's extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,12 +127,8 @@ impl FragmentScanner {
                 // If extensions are specified, proceed only if filename has one of the allowed
                 // extensions.
                 if !self.allowed_extensions.is_empty() {
-                    if let Some(extension) = fpath.extension() {
-                        if let Ok(extension) = &extension.to_owned().into_string() {
-                            if !self.allowed_extensions.contains(extension) {
-                                continue;
-                            }
-                        } else {
+                    if let Some(extension) = fpath.extension().and_then(|x| x.to_str()) {
+                        if !self.allowed_extensions.iter().any(|ax| ax == extension) {
                             continue;
                         }
                     } else {


### PR DESCRIPTION
.iter().any(|e| e == q) is the recommended-by-rustdoc way to spell .contains() with non-identical elements (like the &str vs String here)

Closes: #17