### PR TITLE
Release 0.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.3-alpha.0"
 license = "MIT/Apache-2.0"
 authors = ["Luca Bruno <luca.bruno@coreos.com>", "Robert Fairley <rfairley@redhat.com>"]
 repository = "https://github.com/coreos/liboverdrop-rs"
+readme = "README.md"
 rust-version = "1.56.0"
 edition = "2021"
 exclude = [".gitignore", ".github"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "liboverdrop"
 description = "Configuration library, with directory overlaying and fragments dropins"
-version = "0.0.3-alpha.0"
+version = "0.0.4"
 license = "MIT/Apache-2.0"
 authors = ["Luca Bruno <luca.bruno@coreos.com>", "Robert Fairley <rfairley@redhat.com>"]
 repository = "https://github.com/coreos/liboverdrop-rs"


### PR DESCRIPTION
Cargo.toml: Link README.md

---

Release 0.0.4

- Repository ownership transferred to coreos/ GH organization
- Refreshed CI, ported to 2021 edition
- Many fewer heap allocations

---

