### PR TITLE
Release 0.1.0, incl. migration guide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "liboverdrop"
 description = "Configuration library, with directory overlaying and fragments dropins"
-version = "0.0.4"
+version = "0.1.0"
 license = "MIT/Apache-2.0"
 authors = ["Luca Bruno <luca.bruno@coreos.com>", "Robert Fairley <rfairley@redhat.com>"]
 repository = "https://github.com/coreos/liboverdrop-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,41 @@
 //!     println!("fragment '{}' located at '{}'", filename.to_string_lossy(), filepath.display());
 //! }
 //! ```
+//!
+//! # Migrating from liboverdrop 0.0.x
+//!
+//! The signature changed from
+//! ```rust,compile_fail
+//! # use liboverdrop::FragmentScanner;
+//! let base_dirs: Vec<String> = vec![/**/];
+//! let shared_path: &str = "config.d";
+//! let allowed_extensions: Vec<String> = vec![/**/];
+//! for (basename, filepath) in FragmentScanner::new(
+//!                                 base_dirs, shared_path, false, allowed_extensions).scan() {
+//!     // basename: String
+//!     // filepath: PathBuf
+//! }
+//! ```
+//! to
+//! ```rust,no_run
+//! # use liboverdrop;
+//! # /*
+//! let base_dirs: IntoIterator<Item = AsRef<Path>> = /* could be anything */;
+//! let shared_path: AsRef<Path> = /* ... */;
+//! let allowed_extensions: &[AsRef<OsStr>] = &[/* ... */];
+//! # */
+//! # let base_dirs = [""];
+//! # let shared_path = "";
+//! # let allowed_extensions = &[""];
+//! for (basename, filepath) in liboverdrop::scan(
+//!                                 base_dirs, shared_path, allowed_extensions, false) {
+//!     // basename: OsString
+//!     // filepath: PathBuf
+//! }
+//! ```
+//!
+//! When updating, re-consider if you need to allocate any argument now,
+//! since they can all be literals or borrowed.
 
 use log::trace;
 use std::collections::BTreeMap;


### PR DESCRIPTION
Migration guide render:
![image](https://user-images.githubusercontent.com/6709544/216678696-c431ce58-ff07-40e1-ac83-258e162a9b66.png)

and sd/z-g diff (+14 -20!):
```diff
diff --git a/Cargo.toml b/Cargo.toml
index dfd330c..b680ea5 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ authors = ["Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>",
 license = "MIT"
 description = "Systemd unit generator for zram swap devices."
 homepage = "https://github.com/systemd/zram-generator"
-edition = "2018"
+edition = "2021"
 exclude = ["tests/07a-mount-point-excl", "tests/10-example"]
 
 [dependencies]
 anyhow = "1.0.12"
 clap = { version = "2.33", default-features = false }
-liboverdrop = "0.0.2"
+liboverdrop = { path = "../liboverdrop-rs" }
 rust-ini = ">=0.15, <0.18"
 log = { version = "0.4", features = ["std"] }
 fasteval = { version = "0.2", default-features = false }
diff --git a/src/config.rs b/src/config.rs
index 9d64c1e..69db755 100644
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,10 +3,10 @@
 use anyhow::{anyhow, Context, Result};
 use fasteval::Evaler;
 use ini::Ini;
-use liboverdrop::FragmentScanner;
 use log::{info, warn};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
+use std::ffi::OsString;
 use std::fmt;
 use std::fs;
 use std::io::{prelude::*, BufReader};
@@ -248,35 +248,29 @@ fn read_devices(
     Ok(devices)
 }
 
-fn locate_fragments(root: &Path) -> BTreeMap<String, PathBuf> {
-    let base_dirs = vec![
-        String::from(root.join("usr/lib").to_str().unwrap()),
-        String::from(root.join("usr/local/lib").to_str().unwrap()),
-        String::from(root.join("etc").to_str().unwrap()),
-        String::from(root.join("run").to_str().unwrap()), // We look at /run to allow temporary overriding
-                                                          // of configuration. There is no expectation of
-                                                          // programatic creation of config there.
+fn locate_fragments(root: &Path) -> BTreeMap<OsString, PathBuf> {
+    let base_dirs = [
+        root.join("usr/lib"),
+        root.join("usr/local/lib"),
+        root.join("etc"),
+        root.join("run"), // We look at /run to allow temporary overriding
+                          // of configuration. There is no expectation of
+                          // programatic creation of config there.
     ];
 
-    let cfg = FragmentScanner::new(
-        base_dirs.clone(),
-        "systemd/zram-generator.conf.d",
-        true,
-        vec![String::from("conf")],
-    );
+    let mut fragments =
+        liboverdrop::scan(&base_dirs, "systemd/zram-generator.conf.d", &["conf"], true);
 
-    let mut fragments = cfg.scan();
     if let Some(path) = base_dirs
         .into_iter()
         .rev()
-        .map(PathBuf::from)
         .map(|mut p| {
             p.push("systemd/zram-generator.conf");
             p
         })
         .find(|p| p.exists())
     {
-        fragments.insert(String::new(), path); // The empty string shall sort earliest
+        fragments.insert(OsString::new(), path); // The empty string shall sort earliest
     }
     fragments
 }
```

I trust you'll do the release per norm, bundling the migration guide and version bump makes sense.