### PR TITLE
cargo: avoid deprecated syntax in license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "liboverdrop"
 description = "Configuration library, with directory overlaying and fragments dropins"
 version = "0.1.0"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Luca Bruno <luca.bruno@coreos.com>", "Robert Fairley <rfairley@redhat.com>"]
 repository = "https://github.com/coreos/liboverdrop-rs"
 readme = "README.md"


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#slash