### PR TITLE
Bump MSRV to 1.64.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 authors = ["Luca Bruno <luca.bruno@coreos.com>", "Robert Fairley <rfairley@redhat.com>"]
 repository = "https://github.com/coreos/liboverdrop-rs"
 readme = "README.md"
-rust-version = "1.56.0"
+rust-version = "1.64.0"
 edition = "2021"
 exclude = [".gitignore", ".github"]
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,7 +4,7 @@
 
 Changes:
 
-- Require Rust ≥ 1.56.0
+- Require Rust ≥ 1.64.0
 - Add release notes doc
 
 New contributors:


### PR DESCRIPTION
log 0.4.19 needs at least 1.60.0.  crates.io knows of two dependents for us: Zincati, with an MSRV of 1.64.0, and zram-generator, which doesn't seem to declare one.  Bump up to 1.64.0.